### PR TITLE
Correct issue faced when reaching percent_bytes warn or critical uasg…

### DIFF
--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -97,17 +97,19 @@ class CheckDisk < Sensu::Plugin::Check::CLI
 
   def check_mount(line)
     fs_info = Filesystem.stat(line.mount_point)
-    if @fs_info.respond_to?(:inodes) # needed for windows
-      if percent_inodes(fs_info) >= config[:icrit]
-        @crit_fs << "#{line.mount_point} #{percent_inodes}% inode usage"
-      elsif percent_inodes(fs_info) >= config[:iwarn]
-        @warn_fs << "#{line.mount_point} #{percent_inodes}% inode usage"
+    if fs_info.respond_to?(:inodes) # needed for windows
+      percent_i = percent_inodes(fs_info)
+      if percent_i >= config[:icrit]
+        @crit_fs << "#{line.mount_point} #{percent_i}% inode usage"
+      elsif percent_i >= config[:iwarn]
+        @warn_fs << "#{line.mount_point} #{percent_i}% inode usage"
       end
     end
-    if percent_bytes(fs_info) >= config[:bcrit]
-      @crit_fs << "#{line.mount_point} #{percent_bytes}% bytes usage"
-    elsif percent_bytes(fs_info) >= config[:bwarn]
-      @warn_fs << "#{line.mount_point} #{percent_bytes}% bytes usage"
+    percent_b = percent_bytes(fs_info)
+    if percent_b >= config[:bcrit]
+      @crit_fs << "#{line.mount_point} #{percent_b}% bytes usage"
+    elsif percent_b >= config[:bwarn]
+      @warn_fs << "#{line.mount_point} #{percent_b}% bytes usage"
     end
   end
 


### PR DESCRIPTION
Correct issue faced when reaching percent_bytes warn or critical uasgae: Check failed to run: wrong number of arguments (0 for 1), ["/usr/local/share/gems/gems/sensu-plugins-disk-checks-0.0.2/bin/check-disk-usage.rb:128:in `percent_bytes'", "/usr/local/share/gems/gems/sensu-plugins-disk-checks-0.0.2/bin/check-disk-usage.rb:113:in `check_mount'", "/usr/local/share/gems/gems/sensu-plugins-disk-checks-0.0.2/bin/check-disk-usage.rb:94:in `block in fs_mounts'", "/usr/local/share/gems/gems/sensu-plugins-disk-checks-0.0.2/bin/check-disk-usage.rb:86:in `each'", "/usr/local/share/gems/gems/sensu-plugins-disk-checks-0.0.2/bin/check-disk-usage.rb:86:in `fs_mounts'", "/usr/local/share/gems/gems/sensu-plugins-disk-checks-0.0.2/bin/check-disk-usage.rb:142:in `run'", "/usr/local/share/gems/gems/sensu-plugin-1.1.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]

Correct check of inodes method on object fs_info which was always returning false