### PR TITLE
Adaptive thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ the minimum size volume to adjust the thresholds for.
 Refer to [check_mk's](https://mathias-kettner.de/checkmk_filesystems.html)
 documentation on adaptive thresholds.
 
+You can also visualize the adjustment using
+[WolframAlpha]([https://www.wolframalpha.com/input/) with the following:
+
+    y = 100 - (100-P)*(N^(1-m))/(x^(1-m)), y = P for x in 0 to 1024
+
+Where P = base percentage, N = normalize factor, and m = magic factor
+
 **check-fs-writeable**
 
 Check to make sure a filesytem is writable.  This will check both proc and do a smoke test of each given mountpoint.  It can also auto-discover mount points in the self namespace.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Check disk capacity and inodes based upon the output of df.
 
 Check disk capacity and inodes based upon the gem sys-filesystem.
 
+Can adjust thresholds for larger filesystems by providing a 'magic factor'
+(`-m`).  The default, `1.0`, will not adapt threshold percentages for volumes.
+
+The `-l` option can be used in combination with the 'magic factor' to specify
+the minimum size volume to adjust the thresholds for.
+
+Refer to [check_mk's](https://mathias-kettner.de/checkmk_filesystems.html)
+documentation on adaptive thresholds.
+
 **check-fs-writeable**
 
 Check to make sure a filesytem is writable.  This will check both proc and do a smoke test of each given mountpoint.  It can also auto-discover mount points in the self namespace.

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -72,6 +72,26 @@ class CheckDisk < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: 95
 
+  option :magic,
+         short: '-m MAGIC',
+         description: 'Magic factor to adjust warn/crit thresholds. Example: .9',
+         proc: proc(&:to_f),
+         default: 1.0
+
+  option :normal,
+         short: '-n NORMAL',
+         description: 'Levels are not adapted for filesystems of excatly this '\
+          'size, where levels are reduced for smaller filesystems and raised '\
+          'for larger filesystems.',
+         proc: proc(&:to_f),
+         default: 20
+
+  option :minimum,
+         short: '-l MINIMUM',
+         description: 'Minimum size to adjust (in GB)',
+         proc: proc(&:to_f),
+         default: 100
+
   # Setup variables
   #
   def initialize
@@ -95,6 +115,15 @@ class CheckDisk < Sensu::Plugin::Check::CLI
     end
   end
 
+  # Adjust the percentages based on volume size
+  #
+  def adj_percent(size,percent)
+    hsize = (size / (1024.0 * 1024.0 )) / config[:normal].to_f
+    felt  = hsize ** config[:magic]
+    scale = felt / hsize
+    100 - (( 100 - percent ) * scale)
+  end
+
   def check_mount(line)
     fs_info = Filesystem.stat(line.mount_point)
     if fs_info.respond_to?(:inodes) # needed for windows
@@ -106,11 +135,34 @@ class CheckDisk < Sensu::Plugin::Check::CLI
       end
     end
     percent_b = percent_bytes(fs_info)
-    if percent_b >= config[:bcrit]
-      @crit_fs << "#{line.mount_point} #{percent_b}% bytes usage"
-    elsif percent_b >= config[:bwarn]
-      @warn_fs << "#{line.mount_point} #{percent_b}% bytes usage"
+
+    if fs_info.bytes_total < (config[:minimum] * 1000000000)
+      bcrit = config[:bcrit]
+      bwarn = config[:bwarn]
+    else
+      bcrit = adj_percent(fs_info.bytes_total,config[:bcrit])
+      bwarn = adj_percent(fs_info.bytes_total,config[:bwarn])
     end
+
+    used = to_human(fs_info.bytes_used)
+    total = to_human(fs_info.bytes_total)
+
+    if percent_b >= bcrit
+      @crit_fs << "#{line.mount_point} #{percent_b}% bytes usage (#{used}/#{total})"
+    elsif percent_b >= bwarn
+      @warn_fs << "#{line.mount_point} #{percent_b}% bytes usage (#{used}/#{total})"
+    end
+  end
+
+  def to_human(s)
+    prefix = %W(TiB GiB MiB KiB B)
+    s.to_f
+    i = prefix.length - 1
+    while s > 512 && i > 0
+      s /= 1024
+      i -= 1
+    end
+    ((s > 9 || s.modulo(1) < 0.1 ? '%d' : '%.1f') % s) + ' ' + prefix[i]
   end
 
   # Determine the percent inode usage

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -117,11 +117,11 @@ class CheckDisk < Sensu::Plugin::Check::CLI
 
   # Adjust the percentages based on volume size
   #
-  def adj_percent(size,percent)
-    hsize = (size / (1024.0 * 1024.0 )) / config[:normal].to_f
-    felt  = hsize ** config[:magic]
+  def adj_percent(size, percent)
+    hsize = (size / (1024.0 * 1024.0)) / config[:normal].to_f
+    felt  = hsize**config[:magic]
     scale = felt / hsize
-    100 - (( 100 - percent ) * scale)
+    100 - ((100 - percent) * scale)
   end
 
   def check_mount(line)
@@ -136,12 +136,12 @@ class CheckDisk < Sensu::Plugin::Check::CLI
     end
     percent_b = percent_bytes(fs_info)
 
-    if fs_info.bytes_total < (config[:minimum] * 1000000000)
+    if fs_info.bytes_total < (config[:minimum] * 1_000_000_000)
       bcrit = config[:bcrit]
       bwarn = config[:bwarn]
     else
-      bcrit = adj_percent(fs_info.bytes_total,config[:bcrit])
-      bwarn = adj_percent(fs_info.bytes_total,config[:bwarn])
+      bcrit = adj_percent(fs_info.bytes_total, config[:bcrit])
+      bwarn = adj_percent(fs_info.bytes_total, config[:bwarn])
     end
 
     used = to_human(fs_info.bytes_used)
@@ -155,7 +155,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   end
 
   def to_human(s)
-    prefix = %W(TiB GiB MiB KiB B)
+    prefix = %w(TiB GiB MiB KiB B)
     s.to_f
     i = prefix.length - 1
     while s > 512 && i > 0


### PR DESCRIPTION
Related issue: #14 

This provides "adaptive thresholds" for the percentages.  For instance, 10% free of a 100GB volume is arguably more severe than 10% free of a 10TB volume.  Adapting the thresholds based on volume size would allow for a single check to be more fitting of different volumes without triggering undesirable alerts.

This features is available in check_mk's disk check.  I've forked the Sensu plugin here and added this functionality in if anyone would like to take a look and consider it:
https://github.com/sensu-plugins/sensu-plugins-disk-checks/compare/master...joshbeard:adaptive?expand=1

The idea is that you provide base percentages for warning and critical thresholds.  These percentages are slightly adjusted for larger filesystems based on a "magic factor" the user can provide.  A magic factor of 0 (the default) does no adjustment at all (current behavior).  There's also an option to modify the normalized factor, where volumes of exactly that size will not be adjusted.  Finally, there's an option to specify a minimum size to adjust, so volumes smaller than this will not be adapted.

This can be visualized with [WolframAlpha](https://www.wolframalpha.com/input/) with something like the following:

    y = 100 - (100-P)*(N^(1-m))/(x^(1-m)), y = P for x in 0 to 1024

_Where P = base percentage, N = normalize factor, and m = magic factor_