### PR TITLE
Work around disk permission issue

### DIFF
--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -137,7 +137,12 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   end
 
   def check_mount(line)
-    fs_info = Filesystem.stat(line.mount_point)
+    begin
+      fs_info = Filesystem.stat(line.mount_point)
+    rescue
+      @warn_fs << "#{line.mount_point} Unable to read."
+      return
+    end
     if fs_info.respond_to?(:inodes) # needed for windows
       percent_i = percent_inodes(fs_info)
       if percent_i >= config[:icrit]


### PR DESCRIPTION
There are certain disks which the Sensu user does not have permission to access.
When the plugin encounters those in the default version, it crashes.

```
Check failed to run: statvfs() function failed: Permission denied, 
["/usr/local/share/ruby/gems/2.0/gems/sys-filesystem-1.1.4/lib/unix/sys/filesystem.rb:201:in `stat'"
```
This is a quick alteration to throw a warning instead, and continue on with the rest of the checks.