### PR TITLE
Added include and ignore options for devices

### DIFF
--- a/bin/metrics-disk.rb
+++ b/bin/metrics-disk.rb
@@ -18,6 +18,8 @@
 # USAGE:
 #
 # NOTES:
+#   Devices can be specifically included or ignored using -i or -I options:
+#     e.g. metrics-disk.rb -I [svx]d[a-z][0-9]*
 #
 # LICENSE:
 #   Copyright 2012 Sonian, Inc <chefs@sonian.net>
@@ -48,6 +50,18 @@ class DiskGraphite < Sensu::Plugin::Metric::CLI::Graphite
          short: '-c',
          long: '--convert',
          default: false
+         
+  option :ignore_device,
+         description: 'Ignore devices matching pattern(s)',
+         short: '-i DEV[,DEV]',
+         long: '--ignore-device',
+         proc: proc { |a| a.split(',') }
+
+  option :include_device,
+         description: 'Include only devices matching pattern(s)',
+         short: '-I DEV[,DEV]',
+         long: '--include-device',
+         proc: proc { |a| a.split(',') }
 
   # Main function
   def run
@@ -61,6 +75,9 @@ class DiskGraphite < Sensu::Plugin::Metric::CLI::Graphite
         dev = `lsblk -P -o NAME /dev/"#{dev}"| cut -d\\" -f2`.lines.first.chomp! if dev =~ /^dm-.*$/
       end
       next if stats == ['0'].cycle.take(stats.size)
+      
+      next if config[:ignore_device] && config[:ignore_device].find { |x| dev.match(x) }
+      next if config[:include_device] && !config[:include_device].find { |x| dev.match(x) }
 
       metrics.size.times { |i| output "#{config[:scheme]}.#{dev}.#{metrics[i]}", stats[i] }
     end

--- a/bin/metrics-disk.rb
+++ b/bin/metrics-disk.rb
@@ -50,7 +50,7 @@ class DiskGraphite < Sensu::Plugin::Metric::CLI::Graphite
          short: '-c',
          long: '--convert',
          default: false
-         
+
   option :ignore_device,
          description: 'Ignore devices matching pattern(s)',
          short: '-i DEV[,DEV]',
@@ -75,7 +75,7 @@ class DiskGraphite < Sensu::Plugin::Metric::CLI::Graphite
         dev = `lsblk -P -o NAME /dev/"#{dev}"| cut -d\\" -f2`.lines.first.chomp! if dev =~ /^dm-.*$/
       end
       next if stats == ['0'].cycle.take(stats.size)
-      
+
       next if config[:ignore_device] && config[:ignore_device].find { |x| dev.match(x) }
       next if config[:include_device] && !config[:include_device].find { |x| dev.match(x) }
 


### PR DESCRIPTION
Devices now can be specifically included or ignored using `-i` or `-I` options