### PR TITLE
check-smart-status: Add --json to specify smart.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 ### Changed
+- Adds --json option to check-smart-status.rb
 - Let check-smart-status.rb skip SMART incapable disks
 
 ## [1.1.2] - 2015-12-14

--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -72,6 +72,13 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
          required: false,
          default: 'smartctl'
 
+  option :json,
+         short: '-j path/to/smart.json',
+         long: '--json path/to/smart.json',
+         description: 'Path to SMART attributes JSON file',
+         required: false,
+         default: File.dirname(__FILE__) + '/smart.json'
+
   option :defaults,
          short: '-d 0,0,0,0',
          long: '--defaults 0,0,0,0',
@@ -120,7 +127,7 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
   # Main function
   #
   def run
-    @smart_attributes = JSON.parse(IO.read(File.dirname(__FILE__) + '/smart.json'), symbolize_names: true)[:smart][:attributes]
+    @smart_attributes = JSON.parse(IO.read(config[:json]), symbolize_names: true)[:smart][:attributes]
     @smart_debug = config[:debug] == 'on'
 
     # Set default threshold


### PR DESCRIPTION
The path to `smart.json` is hard-coded but the file itself isn't included in the gem. This is inconvenient because we need to put a `smart.json` file where `check-smart-status.rb` file is installed.

As a fix to the issue, I've added `--json` option to specify the path.