### PR TITLE
check-smart-status: Skip SMART incapable disks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Changed
+- Let check-smart-status.rb skip SMART incapable disks
 
 ## [1.1.2] - 2015-12-14
 ### Added

--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -241,7 +241,11 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
     devices = []
     all.each do |line|
       partition = line.scan(/\w+/).last.scan(/^\D+$/).first
-      devices << partition unless partition.nil?
+      next if partition.nil?
+      output = `sudo #{config[:binary]} -i /dev/#{partition}`
+      available = !output.scan(/SMART support is: Available/).empty?
+      enabled = !output.scan(/SMART support is: Enabled/).empty?
+      devices << partition if available && enabled
     end
 
     devices


### PR DESCRIPTION
This PR lets `check-smart-status.rb` check SMART capabilities. I found it useful because we can blindly use `--device all` whether or not there're drives that don't support SMART.