### PR TITLE
Fix wrong TiB formating in to_human function

### DIFF
--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -178,10 +178,9 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   end
 
   def to_human(s)
-    unit = [[1099511627776, "TiB"],[1073741824, "GiB"], [1048576, "MiB"], [1024, "KiB"], [0,"B"]].detect{ |u| s >= u[0] }
-    "#{s > 0 ? s/unit[0] : s} #{unit[1]}"
+    unit = [[1_099_511_627_776, 'TiB'], [1_073_741_824, 'GiB'], [1_048_576, 'MiB'], [1024, 'KiB'], [0, 'B']].detect { |u| s >= u[0] }
+    "#{s > 0 ? s / unit[0] : s} #{unit[1]}"
   end
-
 
   # Determine the percent inode usage
   #

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -178,15 +178,10 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   end
 
   def to_human(s)
-    prefix = %w(TiB GiB MiB KiB B)
-    s.to_f
-    i = prefix.length - 1
-    while s > 512 && i > 0
-      s /= 1024
-      i -= 1
-    end
-    ((s > 9 || s.modulo(1) < 0.1 ? '%d' : '%.1f') % s) + ' ' + prefix[i]
+    unit = [[1099511627776, "TiB"],[1073741824, "GiB"], [1048576, "MiB"], [1024, "KiB"], [0,"B"]].detect{ |u| s > u[0] }
+    "#{s/unit[0]} #{unit[1]}"
   end
+
 
   # Determine the percent inode usage
   #

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -178,8 +178,8 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   end
 
   def to_human(s)
-    unit = [[1099511627776, "TiB"],[1073741824, "GiB"], [1048576, "MiB"], [1024, "KiB"], [0,"B"]].detect{ |u| s > u[0] }
-    "#{s/unit[0]} #{unit[1]}"
+    unit = [[1099511627776, "TiB"],[1073741824, "GiB"], [1048576, "MiB"], [1024, "KiB"], [0,"B"]].detect{ |u| s >= u[0] }
+    "#{s > 0 ? s/unit[0] : s} #{unit[1]}"
   end
 
 


### PR DESCRIPTION
Fixes bug  mentioned in https://github.com/sensu-plugins/sensu-plugins-disk-checks/issues/25

When:

```
fs_info.bytes_used was 635216715776b
fs_info.bytes_total was 975788797952b
```
old to_human failed to format it resulting in:

```
CheckDisk WARNING: / 65.1% bytes usage (0 TiB/0 TiB) 
```

Simple test script:

```ruby
# Old version
def to_human(s)
    prefix = %w(TiB GiB MiB KiB B)
    s.to_f
    i = prefix.length - 1
    while s > 512 && i > 0
      s /= 1024
      i -= 1
    end
    ((s > 9 || s.modulo(1) < 0.1 ? '%d' : '%.1f') % s) + ' ' + prefix[i]
  end

# New version
def to_human2(s)
  unit = [[1099511627776, "TiB"],[1073741824, "GiB"], [1048576, "MiB"], [1024, "KiB"], [0,"B"]].detect{ |u| s >= u[0] }
  "#{s>0 ? s/unit[0] : s} #{unit[1]}"
end

print to_human(635216715776)
print "\n"
print to_human2(635216715776)
print "\n"
```

Resulting in:

```
0 TiB
591 GiB
```