### PR TITLE
Update check to not divide values less than 1024 by 0.

### DIFF
--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -179,7 +179,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
 
   def to_human(s)
     unit = [[1_099_511_627_776, 'TiB'], [1_073_741_824, 'GiB'], [1_048_576, 'MiB'], [1024, 'KiB'], [0, 'B']].detect { |u| s >= u[0] }
-    "#{s > 0 ? s / unit[0] : s} #{unit[1]}"
+    "#{s >= 1024 ? s / unit[0] : s} #{unit[1]}"
   end
 
   # Determine the percent inode usage


### PR DESCRIPTION
We had an issue where the `to_human` call in `check-disk-usage` would fail when the value of `s` is less than 1024.

I've updated the string to now only divide `s` by its unit amount if `s >= 1024`.