### PR TITLE
Show two decimals of human readable disk space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- check-disk-usage.rb: show the decimals for disk usage figures
 
 ## [2.0.0]
 ### Changed

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -179,7 +179,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
 
   def to_human(s)
     unit = [[1_099_511_627_776, 'TiB'], [1_073_741_824, 'GiB'], [1_048_576, 'MiB'], [1024, 'KiB'], [0, 'B']].detect { |u| s >= u[0] }
-    "%.2f #{unit[1]}" % (s >= 1024 ? s.to_f / unit[0] : s)
+    format("%.2f #{unit[1]}", (s >= 1024 ? s.to_f / unit[0] : s))
   end
 
   # Determine the percent inode usage

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -179,7 +179,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
 
   def to_human(s)
     unit = [[1_099_511_627_776, 'TiB'], [1_073_741_824, 'GiB'], [1_048_576, 'MiB'], [1024, 'KiB'], [0, 'B']].detect { |u| s >= u[0] }
-    "#{s >= 1024 ? s / unit[0] : s} #{unit[1]}"
+    "%.2f #{unit[1]}" % (s >= 1024 ? s.to_f / unit[0] : s)
   end
 
   # Determine the percent inode usage


### PR DESCRIPTION
## Pull Request Checklist

#### General

I'll push a commit updating the changelog.

#### Purpose

Instead of only using whole integers (especially a problem for units of TiB), show two decimal places of information.

I currently have a host showing:

    WARNING: /mnt/other 92.36% bytes usage (1 TiB/1 TiB)

But the actual disk usage is:

    /dev/mapper/BIG-other         2.0T  1.8T  155G  92% /mnt/other

After this change it shows the (IMHO) more useful:

    CheckDisk WARNING: /mnt/other 92.36% bytes usage (1.82 TiB/1.97 TiB)

#### Known Compatablity Issues

If people are parsing the ASCII output of the plugin then the format will change. I wouldn't expect people to be doing that, though.