### PR TITLE
Fix malformed line errors in metrics-disk-capacity.rb by correcting invalid string matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metrics-disk-capacity.rb: fixed invalid string matching with =~ operator
 
 ## [2.0.0]
 ### Changed

--- a/bin/metrics-disk-capacity.rb
+++ b/bin/metrics-disk-capacity.rb
@@ -63,7 +63,7 @@ class DiskCapacity < Sensu::Plugin::Metric::CLI::Graphite
         fs, _type, _blocks, used, avail, capacity, _mnt = line.split
 
         timestamp = Time.now.to_i
-        if fs =~ '/dev'
+        if fs =~ /\/dev/
           fs = fs.gsub('/dev/', '')
           metrics = {
             disk: {
@@ -89,7 +89,7 @@ class DiskCapacity < Sensu::Plugin::Metric::CLI::Graphite
         fs, _inodes, used, avail, capacity, _mnt = line.split
 
         timestamp = Time.now.to_i
-        if fs =~ '/dev'
+        if fs =~ /\/dev/
           fs = fs.gsub('/dev/', '')
           metrics = {
             disk: {


### PR DESCRIPTION
## Pull Request Checklist

Fixes #42 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Fixes invalid string match comparison (comparing String to String instead of String to Regexp) which was introduced by Rubocop autocorrect in https://github.com/sensu-plugins/sensu-plugins-disk-checks/commit/9157c3e91a263c9869c021fbfa250dc67bcc9758

#### Known Compatablity Issues
N/A
