### PR TITLE
Add smartctl device path and parameter override via smart.json configuration for RAID controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Changed
 - check-disk-usage.rb: show the decimals for disk usage figures
+- check-smart.rb: Add path overrides via smart.json
+- check-smart-status.rb: Add path overrides via smart.json
 
 ## [2.0.1] - 2016-06-15
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Check the health of a disk using `smartctl`
 
 ## Usage
 
-This is a sample input file used by check-smart-status, see the script for further details.
+This is a sample input file used by check-smart-status and check-smart, see the script for further details.
 ```json
 {
   "smart": {
@@ -84,6 +84,12 @@ This is a sample input file used by check-smart-status, see the script for furth
       { "id": 201, "name": "Unc_Soft_read_Err_Rate", "read": "left16bit" },
       { "id": 230, "name": "Life_Curve_Status", "crit_min": 100, "warn_min": 100, "warn_max": 100, "crit_max": 100 }
     ]
+  },
+  "hardware": {
+    "devices": [
+	  { "path": "sda", "ignore" : [ 187 ] },
+	  { "path": "sdb", "override": "/dev/twa0 -d 3ware,0" }
+	]
   }
 }
 ```

--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -81,7 +81,7 @@ class Disk
   end
 
   def smart_ignore?(num)
-    return unless !@att_ignore.nil?
+    return if @att_ignore.nil?
     @att_ignore.include? num
   end
 

--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -61,6 +61,36 @@
 require 'sensu-plugin/check/cli'
 require 'json'
 
+class Disk
+  # Setup variables
+  #
+  def initialize(name, override, ignore)
+    @device_path = "/dev/#{name}"
+    @override_path = override
+    @att_ignore = ignore
+  end
+
+  # Is the device SMART capable and enabled
+  #
+  def device_path
+   if @override_path == nil
+      @device_path
+	else
+      @override_path
+    end
+  end
+  
+  def smart_ignore?(num)
+    if @att_ignore == nil
+	  return false
+	else
+      @att_ignore.include? num
+	end
+  end
+  
+   public :device_path, :smart_ignore?
+end
+
 #
 # Smart Check Status
 #
@@ -129,6 +159,9 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
   def run
     @smart_attributes = JSON.parse(IO.read(config[:json]), symbolize_names: true)[:smart][:attributes]
     @smart_debug = config[:debug] == 'on'
+	
+	# Load in the device configuration
+	@hardware = JSON.parse(IO.read(config[:json]), symbolize_names: true)[:hardware][:devices]
 
     # Set default threshold
     default_threshold = config[:defaults].split(',')
@@ -160,7 +193,7 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
     att_check_list = find_attributes
 
     # Devices to check
-    devices = config[:debug_file].nil? ? find_devices : ['sda']
+    devices = config[:debug_file].nil? ? find_devices : [ Disk.new('sda',nil,nil) ]
 
     # Overall health and attributes parameter
     parameters = '-H -A'
@@ -174,10 +207,10 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
     warnings = []
     criticals = []
     devices.each do |dev|
-      puts "#{config[:binary]} #{parameters} /dev/#{dev}" if @smart_debug
+      puts "#{config[:binary]} #{parameters} #{dev.device_path}" if @smart_debug
       # check if debug file specified
       if config[:debug_file].nil?
-        output[dev] = `sudo #{config[:binary]} #{parameters} /dev/#{dev}`
+        output[dev] = `sudo #{config[:binary]} #{parameters} #{dev.device_path}`
       else
         test_file = File.open(config[:debug_file], 'rb')
         output[dev] = test_file.read
@@ -186,13 +219,13 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
 
       # check overall helath status
       if config[:overall] == 'on' && !output[dev].include?('SMART overall-health self-assessment test result: PASSED')
-        criticals << "Overall health check failed on #{dev}"
+        criticals << "Overall health check failed on #{dev.name}"
       end
 
       # #YELLOW
       output[dev].split("\n").each do |line|
         fields = line.split
-        if fields.size == 10 && fields[0].to_i != 0 && att_check_list.include?(fields[0].to_i)
+        if fields.size == 10 && fields[0].to_i != 0 && att_check_list.include?(fields[0].to_i) && ( dev.smart_ignore?(fields[0].to_i) == false )
           smart_att = @smart_attributes.find { |att| att[:id] == fields[0].to_i }
           att_value = fields[9].to_i
           att_value = send(smart_att[:read], att_value) unless smart_att[:read].nil?
@@ -235,25 +268,48 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
   # find all devices from /proc/partitions or from parameter
   #
   def find_devices
-    # Return parameter value if it's defined
-    return config[:devices].split(',') unless config[:devices] == 'all'
-
-    # List all device and split it by new line
-    all = `cat /proc/partitions`.split("\n")
-
-    # Delete first two row (header and empty line)
-    (1..2).each { all.delete_at(0) }
-
     # Search for devices without number
     devices = []
-    all.each do |line|
-      partition = line.scan(/\w+/).last.scan(/^\D+$/).first
-      next if partition.nil?
-      output = `sudo #{config[:binary]} -i /dev/#{partition}`
-      available = !output.scan(/SMART support is: Available/).empty?
-      enabled = !output.scan(/SMART support is: Enabled/).empty?
-      devices << partition if available && enabled
-    end
+	
+    # Return parameter value if it's defined
+	if config[:devices] != 'all'
+	  config[:devices].split(',').each do |dev|
+	    devices << Disk.new("#{dev}","",nil)
+	  end
+	  return devices
+	end
+
+	`lsblk -nro NAME,TYPE`.each_line do |line|
+      name, type = line.split
+      
+	  if type == 'disk'
+		jconfig = @hardware.find { |h1| h1[:path] == name }
+		
+		if jconfig == nil
+		  override = nil
+		  ignore = nil
+		else
+		  override = jconfig[:override] 
+		  ignore = jconfig[:ignore]
+
+		end
+		
+		device = Disk.new(name, override, ignore )
+		
+		output = `sudo #{config[:binary]} -i #{device.device_path}`
+	    
+		# Check if we can use this device or not
+		available = !output.scan(/SMART support is: Available/).empty?
+        enabled = !output.scan(/SMART support is: Enabled/).empty?
+	  
+	    #if available && enabled
+		#  print("Adding #{name} path: #{device.device_path}\n")
+	    devices << device if available && enabled
+		#else
+		#  print("Skipping #{name} path: #{device.device_path}\n")
+		#end
+      end
+	end
 
     devices
   end

--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -79,11 +79,11 @@ class Disk
       @override_path
     end
   end
-  
+
   def smart_ignore?(num)
     if @att_ignore.nil?
       return false
-	  else
+    else
       @att_ignore.include? num
     end
   end
@@ -273,36 +273,36 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
 
     # Return parameter value if it's defined
     if config[:devices] != 'all'
-	    config[:devices].split(',').each do |dev|
+      config[:devices].split(',').each do |dev|
         devices << Disk.new("#{dev}","",nil)
       end
       return devices
     end
 
-	  `lsblk -nro NAME,TYPE`.each_line do |line|
+    `lsblk -nro NAME,TYPE`.each_line do |line|
       name, type = line.split
 
       if type == 'disk'
       jconfig = @hardware.find { |h1| h1[:path] == name }
 
-		  if jconfig.nil?
+      if jconfig.nil?
         override = nil
-		    ignore = nil
-		  else
+        ignore = nil
+      else
         override = jconfig[:override] 
         ignore = jconfig[:ignore]
-		  end
-
-		  device = Disk.new(name,override,ignore)
-
-		  output = `sudo #{config[:binary]} -i #{device.device_path}`
-
-		  # Check if we can use this device or not
-		  available = !output.scan(/SMART support is:\+sAvailable/).empty?
-      enabled = !output.scan(/SMART support is:\+sEnabled/).empty?
-	    devices << device if available && enabled
       end
-	  end
+
+      device = Disk.new(name, override, ignore)
+
+      output = `sudo #{config[:binary]} -i #{device.device_path}`
+
+      # Check if we can use this device or not
+      available = !output.scan(/SMART support is:\+sAvailable/).empty?
+      enabled = !output.scan(/SMART support is:\+sEnabled/).empty?
+        devices << device if available && enabled
+      end
+    end
 
     devices
   end

--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -81,11 +81,8 @@ class Disk
   end
 
   def smart_ignore?(num)
-    if @att_ignore.nil?
-      return false
-    else
-      @att_ignore.include? num
-    end
+    return unless !@att_ignore.nil?
+    @att_ignore.include? num
   end
 
   public :device_path, :smart_ignore?
@@ -274,7 +271,7 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
     # Return parameter value if it's defined
     if config[:devices] != 'all'
       config[:devices].split(',').each do |dev|
-        devices << Disk.new("#{dev}","",nil)
+        devices << Disk.new(dev.to_s, '', nil)
       end
       return devices
     end
@@ -283,23 +280,23 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
       name, type = line.split
 
       if type == 'disk'
-      jconfig = @hardware.find { |h1| h1[:path] == name }
+        jconfig = @hardware.find { |h1| h1[:path] == name }
 
-      if jconfig.nil?
-        override = nil
-        ignore = nil
-      else
-        override = jconfig[:override] 
-        ignore = jconfig[:ignore]
-      end
+        if jconfig.nil?
+          override = nil
+          ignore = nil
+        else
+          override = jconfig[:override]
+          ignore = jconfig[:ignore]
+        end
 
-      device = Disk.new(name, override, ignore)
+        device = Disk.new(name, override, ignore)
 
-      output = `sudo #{config[:binary]} -i #{device.device_path}`
+        output = `sudo #{config[:binary]} -i #{device.device_path}`
 
-      # Check if we can use this device or not
-      available = !output.scan(/SMART support is:\+sAvailable/).empty?
-      enabled = !output.scan(/SMART support is:\+sEnabled/).empty?
+        # Check if we can use this device or not
+        available = !output.scan(/SMART support is:\+sAvailable/).empty?
+        enabled = !output.scan(/SMART support is:\+sEnabled/).empty?
         devices << device if available && enabled
       end
     end

--- a/bin/check-smart.rb
+++ b/bin/check-smart.rb
@@ -137,7 +137,7 @@ class CheckSMART < Sensu::Plugin::Check::CLI
       if type == 'disk'
         jconfig = @hardware.find { |h1| h1[:path] == name }
 	
-        override = !jconfig.nil? jconfig[:override] : nil
+        override = !jconfig.nil? ? jconfig[:override] : nil
 	
         device = Disk.new(name, override, config[:binary])
 		

--- a/bin/check-smart.rb
+++ b/bin/check-smart.rb
@@ -108,7 +108,7 @@ class CheckSMART < Sensu::Plugin::Check::CLI
          description: 'smartctl binary to use, in case you hide yours',
          required: false,
          default: 'smartctl'
-	 
+
   option :json,
          short: '-j path/to/smart.json',
          long: '--json path/to/smart.json',
@@ -133,16 +133,16 @@ class CheckSMART < Sensu::Plugin::Check::CLI
   def scan_disks!
     `lsblk -nro NAME,TYPE`.each_line do |line|
       name, type = line.split
-      
+
       if type == 'disk'
         jconfig = @hardware.find { |h1| h1[:path] == name }
-	
+
         override = !jconfig.nil? ? jconfig[:override] : nil
-	
+
         device = Disk.new(name, override, config[:binary])
-		
+
         output = `sudo #{config[:binary]} -i #{device.device_path}`
-	    
+
         # Check if we can use this device or not
         available = !output.scan(/SMART support is:\s+Available/).empty?
         enabled = !output.scan(/SMART support is:\s+Enabled/).empty?
@@ -151,7 +151,7 @@ class CheckSMART < Sensu::Plugin::Check::CLI
       end
     end
   end
-  
+
   # Main function
   #
   def run


### PR DESCRIPTION
## Pull Request Checklist

Adding device path & parameter override to allow smartctl access to 3ware (and other) RAID controller. Added this to check-smart.rb and check-smart-status.rb.

Also added an ignore attribute option to explicitly ignore attributes with yakky values. My intel 520 is reporting massive uncorrected inputs but is actually fine. Other users (on google search) have reported 
the same issue with this SSD.
#48
#### General
- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [X] Update README with any necessary configuration snippets
#### Purpose
#### Known Compatablity Issues

Not tested against any other RAID controller but it 'should' work given that the link below states fairly similar parameter configuration.

Smartctl RAID paramteres(https://www.smartmontools.org/wiki/Supported_RAID-Controllers)
