### PR TITLE
Ignore utilization checks of devfs filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Changed
 - check-disk-usage.rb: show the decimals for disk usage figures
+- check-disk-usage.rb: dont do utilization check of devfs filesystems
 
 ### Fixed
 - check-fstab-mounts.rb: support swap mounts defined using UUID or LABEL

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -149,6 +149,9 @@ class CheckDisk < Sensu::Plugin::Check::CLI
       @warn_fs << "#{line.mount_point} Unable to read."
       return
     end
+    if line.mount_type == 'devfs'
+      return
+    end
     if fs_info.respond_to?(:inodes) && !fs_info.inodes.nil? # needed for windows
       percent_i = percent_inodes(fs_info)
       if percent_i >= config[:icrit]


### PR DESCRIPTION
Fixes #63.

I placed the if statement there because it causes the readability check just above it, to be run before we check if the mount is devfs.
