### PR TITLE
bump sys-filesystem to 1.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Changed
 - check-disk-usage.rb: show the decimals for disk usage figures
 - check-disk-usage.rb: dont do utilization check of devfs filesystems
+- bump sys-filesystem to 1.1.7
 
 ### Fixed
 - check-fstab-mounts.rb: support swap mounts defined using UUID or LABEL

--- a/sensu-plugins-disk-checks.gemspec
+++ b/sensu-plugins-disk-checks.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsDiskChecks::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'sys-filesystem', '1.1.5'
+  s.add_runtime_dependency 'sys-filesystem', '1.1.7'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist

#https://github.com/sensu/sensu-omnibus/issues/179

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

#### Purpose

Update sys-filesystem 1.1.7 to fix a crash in Ruby on RHEL 6.9 systems.

#### Known Compatablity Issues

