### PR TITLE
Accomodate LVM devices as Swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Fixed
 - check-fstab-mounts.rb: support swap mounts defined using UUID or LABEL
+- check-fstab-mounts.rb: support swap mounts defined using LVM /dev/mapper/*
 
 ## [2.0.1] - 2016-06-15
 ### Fixed

--- a/bin/check-fstab-mounts.rb
+++ b/bin/check-fstab-mounts.rb
@@ -68,6 +68,12 @@ class CheckFstabMounts < Sensu::Plugin::Check::CLI
       end
     end
 
+    if d.start_with?('/dev/mapper')
+      if File.symlink?(d)
+        d = File.realpath(d, '/')
+      end
+    end
+
     d
   end
 


### PR DESCRIPTION
When a LVM device is specified in fstab using the volume name (e.g.
/dev/mapper/vg_root-lv_swap), it does not match the device in
/proc/swaps (e.g /dev/dm-1).

This change resolves the fstab representation to the proc
representation.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

