### PR TITLE
check-smart.rb: more flexible with smartctl output whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Fixed
 - fixed spelling of "Compatibility" in PR template (@majormoses)
+- check-smart.rb: deal with long keys in the info output
 
 ## [2.2.0] - 2017-06-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Fixed
 - fixed spelling of "Compatibility" in PR template (@majormoses)
 - check-smart.rb: deal with long keys in the info output
+- check-smart.rb: accept "OK" disk health status
 
 ## [2.2.0] - 2017-06-24
 ### Added

--- a/bin/check-smart.rb
+++ b/bin/check-smart.rb
@@ -74,7 +74,7 @@ class Disk
   #
   def check_health!
     output = `sudo smartctl -H #{@device_path}`
-    @smart_healthy = !output.scan(/PASSED/).empty?
+    @smart_healthy = !output.scan(/PASSED|OK$/).empty?
     @health_output = output
   end
 end

--- a/bin/check-smart.rb
+++ b/bin/check-smart.rb
@@ -65,8 +65,8 @@ class Disk
   #
   def check_smart_capability!
     output = `sudo smartctl -i #{@device_path}`
-    @smart_available = !output.scan(/SMART support is: Available/).empty?
-    @smart_enabled = !output.scan(/SMART support is: Enabled/).empty?
+    @smart_available = !output.scan(/SMART support is:\s*Available/).empty?
+    @smart_enabled = !output.scan(/SMART support is:\s*Enabled/).empty?
     @capability_output = output
   end
 

--- a/bin/check-smart.rb
+++ b/bin/check-smart.rb
@@ -65,8 +65,8 @@ class Disk
   #
   def check_smart_capability!
     output = `sudo smartctl -i #{@device_path}`
-    @smart_available = !output.scan(/SMART support is:\s*Available/).empty?
-    @smart_enabled = !output.scan(/SMART support is:\s*Enabled/).empty?
+    @smart_available = !output.scan(/SMART support is:\s+Available/).empty?
+    @smart_enabled = !output.scan(/SMART support is:\s+Enabled/).empty?
     @capability_output = output
   end
 


### PR DESCRIPTION
This fixes the check when there are longer keys in the info section.

E.g. we've seen this:

```
$ sudo smartctl -i /dev/sda
smartctl 6.5 2016-01-24 r4214 [x86_64-linux-4.4.0-72-generic] (local build)
Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Vendor:               HP
Product:              LOGICAL VOLUME
Revision:             6.00
User Capacity:        1,000,171,331,584 bytes [1.00 TB]
Logical block size:   512 bytes
Logical Unit id:      0x600508b1001cbf6277f0bc12edc01e5f
Serial number:        0014380263C4BD0
Device type:          disk
Local Time is:        Tue Jun 27 16:59:36 2017 UTC
SMART support is:     Available - device has SMART capability.
SMART support is:     Enabled
Temperature Warning:  Disabled or Not Supported

```

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
