### PR TITLE
Regexp syntax fixed in check-smart-status.rb

### DIFF
--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -295,8 +295,8 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
         output = `sudo #{config[:binary]} -i #{device.device_path}`
 
         # Check if we can use this device or not
-        available = !output.scan(/SMART support is:\+sAvailable/).empty?
-        enabled = !output.scan(/SMART support is:\+sEnabled/).empty?
+        available = !output.scan(/SMART support is:\s+Available/).empty?
+        enabled = !output.scan(/SMART support is:\s+Enabled/).empty?
         devices << device if available && enabled
       end
     end


### PR DESCRIPTION
The regexp syntax in function find_devices in check-smart-status.rb had error, causing that this check did not check anything with the message "SmartCheckStatus OK: All device operating properly'.
