### PR TITLE
- check-smart.rb: Removed duplicated smartctl runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- check-smart.rb: The JSON file is now does not need to exist
+
+### Added
+- check-smart.rb: Add support for legacy smartctl output relating to `Available` and `Enabled`
+- check-smart.rb: Add option to specify the exit code to use when there are no smart capable devices
+
+### Removed
+- check-smart.rb: Removed duplicated smartctl runs
 
 ## [2.4.2] - 2017-08-17
 ### Fixed


### PR DESCRIPTION
- check-smart.rb: Removed duplicated smartctl runs
- check-smart.rb: The JSON file is now does not need to exist
- check-smart.rb: Add support for legacy smartctl output relating to `Available` and `Enabled`
- check-smart.rb: Add option to specify the exit code to use when there are no smart capable devices

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
