### PR TITLE
 protect Filesystem.mounts retrieval from failing and exit critical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-disk-usage.rb: now exits unknown instead of critical when retrieving mountpoints fail
 
 ## [2.5.0] - 2017-08-28
 ### Changed

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -118,7 +118,12 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   # Get mount data
   #
   def fs_mounts
-    Filesystem.mounts.each do |line|
+    begin
+      mounts = Filesystem.mounts
+    rescue
+      unknown 'An error occured getting the mount info'
+    end
+    mounts.each do |line|
       begin
         next if config[:fstype] && !config[:fstype].include?(line.mount_type)
         next if config[:ignoretype] && config[:ignoretype].include?(line.mount_type)


### PR DESCRIPTION
## Pull Request Checklist

https://github.com/sensu-plugins/sensu-plugins-disk-checks/issues/65

#### General

if `Filesystem.mounts` fails:  _Permission denied - setmntent_ the checks exits critical

this PR enclose the call in begin/rescue to exit unknown instead of critical when the call fails to retrieve mountpoints.
