### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Breaking Changes
+- removed ruby `< 2.1` support (@majormoses)
+
 ### Changed
 - updated the changelog location guidelines (@majormoses)
+- appeased the cops and created TODOs for refactoring (@majormoses)
 
 ## [2.5.1] - 2017-12-05
 ### Fixed

--- a/Rakefile
+++ b/Rakefile
@@ -8,12 +8,12 @@ require 'yard/rake/yardoc_task'
 
 desc 'Don\'t run Rubocop for unsupported versions'
 
-args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+args = %i[spec make_bin_executable yard rubocop check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -120,7 +120,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   def fs_mounts
     begin
       mounts = Filesystem.mounts
-    rescue
+    rescue StandardError
       unknown 'An error occured getting the mount info'
     end
     mounts.each do |line|
@@ -131,7 +131,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
         next if config[:ignorepathre] && config[:ignorepathre].match(line.mount_point)
         next if config[:ignoreopt] && config[:ignoreopt].include?(line.options)
         next if config[:includemnt] && !config[:includemnt].include?(line.mount_point)
-      rescue
+      rescue StandardError
         unknown 'An error occured getting the mount info'
       end
       check_mount(line)
@@ -150,7 +150,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   def check_mount(line)
     begin
       fs_info = Filesystem.stat(line.mount_point)
-    rescue
+    rescue StandardError
       @warn_fs << "#{line.mount_point} Unable to read."
       return
     end

--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -174,7 +174,7 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
     unless config[:threshold].nil?
       thresholds = config[:threshold].split(',')
       # Check threshold parameter length
-      raise 'Invalid threshold parameter count' unless thresholds.size % 5 == 0
+      raise 'Invalid threshold parameter count' unless (thresholds.size % 5).zero?
 
       (0..(thresholds.size / 5 - 1)).each do |i|
         att_id = @smart_attributes.index { |att| att[:id] == thresholds[i + 0].to_i }
@@ -203,7 +203,8 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
     output = {}
     warnings = []
     criticals = []
-    devices.each do |dev|
+    # TODO: refactor me
+    devices.each do |dev| # rubocop:disable Metrics/BlockLength
       puts "#{config[:binary]} #{parameters} #{dev.device_path}" if @smart_debug
       # check if debug file specified
       if config[:debug_file].nil?

--- a/bin/check-smart-tests.rb
+++ b/bin/check-smart-tests.rb
@@ -59,7 +59,7 @@ class Device
 
   def selftest_results
     results = []
-    headers = %w(num test_description status remaining lifetime lba_of_first_error)
+    headers = %w[num test_description status remaining lifetime lba_of_first_error]
 
     `sudo #{@exec} -l selftest #{@name}`.split("\n").grep(/^#/).each do |test|
       test = test.gsub!(/\s\s+/m, "\t").split("\t")
@@ -146,7 +146,8 @@ class CheckSMARTTests < Sensu::Plugin::Check::CLI
       end
     end
 
-    unless config[:long_test_interval].nil?
+    # TODO: refactor me
+    unless config[:long_test_interval].nil? # rubocop:disable Style/GuardClause
       dev.str.each_with_index do |t, i|
         if t['test_description'] != 'Extended offline'
           if i == dev.str.length - 1

--- a/bin/check-smart.rb
+++ b/bin/check-smart.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
 #
 #   check-smart
 #
@@ -110,14 +109,14 @@ class CheckSMART < Sensu::Plugin::Check::CLI
          description: 'Exit code when SMART is unavailable/disabled on a disk',
          proc: proc(&:to_sym),
          default: :unknown,
-         in: %i(unknown ok warn critical)
+         in: %i[unknown ok warn critical]
 
   option :no_smart_capable_disks,
          long: '--no-smart-capable-disks EXIT_CODE',
          description: 'Exit code when there are no SMART capable disks',
          proc: proc(&:to_sym),
          default: :unknown,
-         in: %i(unknown ok warn critical)
+         in: %i[unknown ok warn critical]
 
   option :binary,
          short: '-b path/to/smartctl',
@@ -170,10 +169,12 @@ class CheckSMART < Sensu::Plugin::Check::CLI
   # Main function
   #
   def run
-    exit_with(
-      config[:no_smart_capable_disks],
-      'No SMART capable devices found'
-    ) unless @devices.length > 0
+    unless @devices.length > 0
+      exit_with(
+        config[:no_smart_capable_disks],
+        'No SMART capable devices found'
+      )
+    end
 
     unhealthy_disks = @devices.select { |disk| disk.smart_capable? && !disk.healthy? }
     unknown_disks = @devices.reject(&:smart_capable?)

--- a/bin/metrics-disk-capacity.rb
+++ b/bin/metrics-disk-capacity.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
 #
 #   disk-capacity-metrics
 #
@@ -78,7 +77,7 @@ class DiskCapacity < Sensu::Plugin::Metric::CLI::Graphite
             end
           end
         end
-      rescue
+      rescue StandardError
         unknown "malformed line from df: #{line}"
       end
     end
@@ -104,7 +103,7 @@ class DiskCapacity < Sensu::Plugin::Metric::CLI::Graphite
             end
           end
         end
-      rescue
+      rescue StandardError
         unknown "malformed line from df: #{line}"
       end
     end

--- a/bin/metrics-disk-usage.rb
+++ b/bin/metrics-disk-usage.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
 #
 #   disk-usage-metrics
 #

--- a/bin/metrics-disk.rb
+++ b/bin/metrics-disk.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
 #
 #   disk-metrics
 #
@@ -66,7 +65,7 @@ class DiskGraphite < Sensu::Plugin::Metric::CLI::Graphite
   # Main function
   def run
     # http://www.kernel.org/doc/Documentation/iostats.txt
-    metrics = %w(reads readsMerged sectorsRead readTime writes writesMerged sectorsWritten writeTime ioInProgress ioTime ioTimeWeighted)
+    metrics = %w[reads readsMerged sectorsRead readTime writes writesMerged sectorsWritten writeTime ioInProgress ioTime ioTimeWeighted]
 
     File.open('/proc/diskstats', 'r').each_line do |line|
       stats = line.strip.split(/\s+/)

--- a/sensu-plugins-disk-checks.gemspec
+++ b/sensu-plugins-disk-checks.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'
 require_relative 'lib/sensu-plugins-disk-checks'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
   # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
                               health, usage, and various metrics.'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-disk-checks'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => '@mattyjones',
@@ -25,13 +25,14 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for disk checks'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsDiskChecks::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+
   s.add_runtime_dependency 'sys-filesystem', '1.1.7'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
@@ -41,6 +42,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Breaking Changes:
- removed ruby `< 2.1` support

Misc:
- appeased the cops and created TODOs for refactoring

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Address CVE-2017-8418, see parent issue for details

#### Known Compatibility Issues
removed ruby `< 2.1` support