### PR TITLE
fix: do not override_path when specifying device from the cli on chec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ### Added
 - check-disk-usage: adds documentation for `-x` and `-p` options
 
+### Fixed
+- `check-smart-status.rb`: do not override_path when specifying device from the CLI. (@marcdeop)
+
 ## [3.1.0] - 2018-05-02
 ### Added
 - metrics-disk-capacity.rb, added `solaris` compatibility. Does not support inodes on `solaris` (@makaveli0129).

--- a/bin/check-smart-status.rb
+++ b/bin/check-smart-status.rb
@@ -272,7 +272,7 @@ class SmartCheckStatus < Sensu::Plugin::Check::CLI
     # Return parameter value if it's defined
     if config[:devices] != 'all'
       config[:devices].split(',').each do |dev|
-        devices << Disk.new(dev.to_s, '', nil)
+        devices << Disk.new(dev.to_s, nil, nil)
       end
       return devices
     end


### PR DESCRIPTION
#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

#### Purpose
`check-smart-status.rb`  was using this call `devices << Disk.new(dev.to_s, '', nil)` which passes an empty path to `@override_path` thus making the check fail by checking an empty path
