### PR TITLE
Change platform to platform_family

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -16,7 +16,7 @@ builds:
   filter:
   -  "entity.system.os == 'linux'"
   -  "entity.system.arch == 'amd64'"
-  -  "entity.system.platform == 'rhel'"
+  -  "entity.system.platform_family == 'rhel'"
 - platform: "alpine"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_alpine_linux_amd64.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- Allow the asset to be filtered correctly on rhel-derived systems when loaded from bonsai (@themysteriousx)
 
 ## [5.0.0] - 2019-04-10
 ### Breaking Changes


### PR DESCRIPTION
In the entity info, redhat systems are listed as:

```
{
  "entity_class": "agent",
  "system": {
    "hostname": "",
    "os": "linux",
    "platform": "redhat",
    "platform_family": "rhel",
    "platform_version": "7.7",
...
```

In order to filter as expected, platform_family should be used.

## Pull Request Checklist

#123 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Bugfix on centos

#### Known Compatibility Issues
Same change may need to be made on other platforms, but I do not have access to them