### PR TITLE
More accurate disk percent usage ignoring privileged bytes Closes #156

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- check-disk-usage.rb: More accurate disk percent usage ignoring privileged bytes (@SaviourSelf)
 
 ## [5.1.1] - 2020-04-22
 ### Changed

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -215,7 +215,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
       if nonroot_total.zero?
         0
       else
-        (u100 / nonroot_total + (u100 % nonroot_total != 0 ? 1 : 0)).truncate(2)
+        ('%.2f' % (u100 / nonroot_total + (u100 % nonroot_total != 0 ? 1 : 0))).to_f
       end
     else
       (100.0 - (100.0 * fs_info.bytes_free / fs_info.bytes_total)).round(2)

--- a/bin/check-disk-usage.rb
+++ b/bin/check-disk-usage.rb
@@ -215,7 +215,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
       if nonroot_total.zero?
         0
       else
-        ('%.2f' % (u100 / nonroot_total + (u100 % nonroot_total != 0 ? 1 : 0))).to_f
+        (u100 / nonroot_total + (u100 % nonroot_total != 0 ? 1 : 0)).round(2)
       end
     else
       (100.0 - (100.0 * fs_info.bytes_free / fs_info.bytes_total)).round(2)


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, see issue: https://github.com/sensu-plugins/sensu-plugins-disk-checks/issues/156

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

N/A

#### Purpose

Purpose is to more accurately reflect the output of the `df` linux command. 

#### Known Compatibility Issues

No known compatibility issues.

#### Example output

##### Windows
```
df -h
Filesystem      Size  Used Avail Use% Mounted on
rootfs          931G  856G   75G  92% /
```

```
./check-disk-usage.rb -p '(\/var|\/run|\/sys|\/dev|\/mnt)' -r
CheckDisk WARNING: / 92.99% bytes usage (855.99 GiB/930.45 GiB)
```
##### Linux
```
df -h
Filesystem      Size  Used Avail Use% Mounted on
rootfs          143G   28G  109G  21% /
```

```
./check-disk-usage.rb -w 10 -r
CheckDisk WARNING: / 21.31% bytes usage (27.55 GiB/142.91 GiB)
./check-disk-usage.rb -w 10
CheckDisk WARNING: / 19.28% bytes usage (27.55 GiB/142.91 GiB)
```